### PR TITLE
add a nicer burndown chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Why waste time and money paying for a Ticket Tracker when you already work in Gi
   - [Moving Cards](#moving-cards)
   - [Task Lists](#task-lists)
   - [CI Status and Merge Conflict](#ci-status-and-merge-conflict)
+  - [Burndown Chart](#burndown-chart)
   - [Easter Eggs](#easter-eggs)
 - [Examples](#examples)
 - [Development](#development)
@@ -92,6 +93,15 @@ By using the `- [ ]` notation in the body of an Issue or Pull Request, the progr
 ![image](https://cloud.githubusercontent.com/assets/253202/13621876/d1bcfeb0-e568-11e5-8a73-c5ef61645a88.png)
 
 ![image](https://cloud.githubusercontent.com/assets/253202/13621905/dfee5920-e568-11e5-94df-98a887f63d24.png)
+
+
+### Burndown Chart
+
+Shows a burndown chart for a Milestone (ie "Sprint" or "Iteration").
+If you use select multiple repositories it will include all of them.
+
+![burndown-chart](https://cloud.githubusercontent.com/assets/253202/14071745/572d85ac-f486-11e5-80a6-024d7c83138f.png)
+
 
 # Easter Eggs
 

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "puzzle-script": "0.0.2",
     "react": "^0.14.7",
     "react-bootstrap": "^0.28.4",
+    "react-d3": "^0.4.0",
     "react-dnd": "^2.1.2",
     "react-dnd-html5-backend": "^2.1.2",
     "react-dom": "^0.14.7",

--- a/src/components/app/nav.jsx
+++ b/src/components/app/nav.jsx
@@ -258,6 +258,7 @@ const AppNav = React.createClass({
               <BS.MenuItem key='manager-pages' header>Manager-ish Pages</BS.MenuItem>
               {managerMenu}
               <SettingsItem key='milestone-planning' to={getFilters().setRouteName('by-milestone').url()}>Milestone Planning View</SettingsItem>
+              <SettingsItem key='burndown' to={getFilters().setRouteName('burndown').url()}>Burndown Chart</SettingsItem>
               <SettingsItem key='gantt-chart' to={getFilters().setRouteName('gantt').url()}>Gantt Chart</SettingsItem>
 
             </BS.NavDropdown>

--- a/src/components/burndown.jsx
+++ b/src/components/burndown.jsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import _ from 'underscore';
+
+import {LineChart} from 'react-d3';
+import Database from '../database';
+import {filterCardsByFilter} from '../route-utils';
+import IssueStore from '../issue-store';
+import Loadable from './loadable';
+
+
+const BurndownShell = React.createClass({
+  componentWillMount() {
+    // Needs to be called before `render()`
+    IssueStore.startPolling();
+  },
+  componentWillUnmount() {
+    IssueStore.stopPolling();
+  },
+  renderLoaded(cards) {
+    function getDay(dateStr) {
+      return Math.floor(Date.parse(dateStr) / 1000 / 60 / 60 / 24);
+    }
+
+    // Get the total number of Issues
+    const total = cards.length;
+
+    if (!cards.length) {
+      return (
+        <span>Not showing a chart because there are 0 cards to show</span>
+      );
+    }
+
+    cards = _.sortBy(cards, (card) => getDay(card.issue.createdAt));
+    // Get the oldest Issue and the newest Issue Date
+    const startDate = cards[0].issue.createdAt;
+    // From this point, we only care about closed Issues
+    cards = cards.filter((card) => card.issue.closedAt);
+    cards = _.sortBy(cards, (card) => getDay(card.issue.closedAt));
+    const endDate = cards[cards.length - 1].issue.closedAt;
+
+    if (!cards.length) {
+      return (
+        <span>Not showing a chart because there are 0 closed cards to show</span>
+      );
+    }
+
+    const startDays = getDay(startDate);
+    const endDays = getDay(endDate);
+    // TODO: If the number of days is more than, say 50, then show changes per week.
+    // Loop over the days and build a chart
+    let openCount = total;
+    const values = [];
+    values.push({x: 0, y: openCount});
+    for (let currentDay = startDays; currentDay <= endDays; currentDay++) {
+      // loop through the cards to count how many have closed on this day
+      let closedToday = 0;
+      for (let cardIndex = 0; cardIndex < cards.length; cardIndex++) {
+        const cardDay = getDay(cards[cardIndex].issue.closedAt);
+        if (cardDay === currentDay) {
+          closedToday++;
+        } else if (cardDay < currentDay) {
+          throw new Error('BUG: Looks like the cards are not sorted properly');
+        } else {
+          break;
+        }
+      }
+      // remove the cards since they are now accounted for
+      if (closedToday) {
+        cards.splice(0, closedToday);
+        openCount -= closedToday;
+        values.push({x: currentDay - startDays, y: openCount});
+      }
+    }
+
+    if (cards.length > 0) {
+      throw new Error('BUG: Should have counted all the cards');
+    }
+
+    const lineData = [
+      {
+        name: 'Remaining Issues',
+        values: values
+      },
+      {
+        name: 'Ideal Burndown',
+        values: [{x: 0, y: total}, {x: endDays - startDays, y: 0}]
+      }
+    ];
+    return (
+      <div>
+        <p>Open Issues remaining: {openCount}</p>
+        <LineChart
+          legend={true}
+          data={lineData}
+          width={600}
+          height={400}
+          viewBoxObject={{
+            x: 0,
+            y: 0,
+            width: 500,
+            height: 400
+          }}
+          title="Burndown Chart"
+          yAxisLabel="Remaining Issues"
+          xAxisLabel="Days"
+          gridHorizontal={true}
+        />
+      </div>
+    );
+  },
+  render() {
+    // TODO: send the current filter as an arg to `Database.fetchCards()` so it can smartly (using Indexes) fetch the cards
+    const promise = Database.fetchCards().then((cards) => {
+      return filterCardsByFilter(cards);
+    });
+
+    return (
+      <div className='burndown'>
+        <h2>Burndown Chart</h2>
+        <p>Make sure you selected <strong>closed</strong> and <strong>Issues</strong> and optionally a Milestone from the filter dropdown at the top of this page</p>
+        <Loadable
+          promise={promise}
+          renderLoaded={this.renderLoaded}
+        />
+      </div>
+    );
+  }
+});
+
+export default BurndownShell;

--- a/src/database.js
+++ b/src/database.js
@@ -162,6 +162,9 @@ const database = new class Database {
   getCard(repoOwner, repoName, number) {
     return this._doOp('issues', 'get', `${repoOwner}/${repoName}#${number}`, this._opts);
   }
+  // TODO: pass a filter as an arg so it can smartly (using Indexes) fetch the cards
+  // ie: If there is just 1 repo then use the repoName index.
+  // ie: If just getting open (or closed) Issues then use the `state` index.
   fetchCards() {
     const {states} = getFilters().getState();
     const db = new Dexie('issues');

--- a/src/router.js
+++ b/src/router.js
@@ -56,6 +56,15 @@ const routes = [
                 callback(null, require('./components/gantt-view').default);
               });
             }
+          },
+          { path: 'burndown',
+            // Keep the review page as a separate chunk because it contains d3
+            getComponent(location, callback) {
+              require.ensure([], (require) => {
+                // Remember to add the `.default`!
+                callback(null, require('./components/burndown').default);
+              });
+            }
           }
       ] },
       // Catch for people blindly replacing "https://github.com/..." with "gh-board/#..."

--- a/style/app.less
+++ b/style/app.less
@@ -964,3 +964,16 @@ i.icon-spin {
 .octicon.private {
   color: #e9dba5;
 }
+
+// burndown chart needs a background color
+.burndown {
+  margin-left: 2rem;
+  .rd3-legend-chart {
+    .rd3-chart { background-color: white; }
+    .rd3-legend {
+      padding-left: 2rem !important; // override the style attribute
+      .rd3-legend-item { white-space: nowrap; }
+    }
+  }
+
+}


### PR DESCRIPTION
This adds a **burndown** chart which can be accessed from the top-right menu.

![image](https://cloud.githubusercontent.com/assets/253202/14071167/0722aff8-f47f-11e5-94d3-c131fa9a35c6.png)


# Simple example

![image](https://cloud.githubusercontent.com/assets/253202/14071745/572d85ac-f486-11e5-80a6-024d7c83138f.png)


# Extreme example 

Uses **all** the Issues in the `openstax` Organization (regardless of Milestone):

![image](https://cloud.githubusercontent.com/assets/253202/14071755/791a562c-f486-11e5-889a-67951aa830d1.png)


Fixes #8 

# TODO

- [x] plot the "Ideal" line as well
- [ ] use Milestone dates for the chart range
- [ ] use weeks instead of days when the range is large
- [ ] overlay a bar chart of the closed Issues for each day/week