### PR TITLE
handle remote label changes

### DIFF
--- a/src/card-model.js
+++ b/src/card-model.js
@@ -181,10 +181,13 @@ export default class Card {
       }
     });
   }
-  fetchIssue() {
+  fetchIssue(skipSavingToDb) {
     return this._getOcto().issues(this.number).fetch().then((issue) => {
       this.issue = issue;
-      Database.putCard(this);
+      if (!skipSavingToDb) {
+        Database.putCard(this);
+      }
+      return issue;
     });
   }
   resetPromisesAndState(issue, pr, prStatus) {

--- a/src/components/app/nav.jsx
+++ b/src/components/app/nav.jsx
@@ -98,7 +98,7 @@ const AppNav = React.createClass({
       // TODO: HACK. Find a better way to update the color of labels
       const label = LABEL_CACHE[tagName] || {name: tagName, color: 'ffffff'};
       return (
-        <LabelBadge key={tagName} isClickable label={label}/>
+        <LabelBadge key={tagName} isFilterLink label={label}/>
       );
     });
 
@@ -268,6 +268,7 @@ const AppNav = React.createClass({
               <SettingsItem key='milestone-planning' to={getFilters().setRouteName('by-milestone').url()}>Milestone Planning View</SettingsItem>
               <SettingsItem key='burnup' to={getFilters().setRouteName('burnup').url()}><i className='octicon octicon-graph'/> Burnup Chart</SettingsItem>
               <SettingsItem key='gantt-chart' to={getFilters().setRouteName('gantt').url()}><i className='octicon octicon-graph'/> Gantt Chart</SettingsItem>
+              <SettingsItem key='label-editing' to={getFilters().setRouteName('labels').url()}><i className='octicon octicon-tag'/> Label Editing</SettingsItem>
               <BS.MenuItem key='reset-databases' onClick={this.promptAndResetDatabases}>Reset Local Cache...</BS.MenuItem>
             </BS.NavDropdown>
             {loginButton}

--- a/src/components/batch-labels.jsx
+++ b/src/components/batch-labels.jsx
@@ -1,0 +1,162 @@
+// Tabs:
+// - columns
+// - labels
+// - milestones
+
+// Panels:
+// - Primary Repository
+//   - show count of other repos that have that label (& list the repos on hover)
+// - Several Repositories (migrate to labels in the primary repository)
+//   - show count of other repos that have that label (& list the repos on hover)
+// - Only 1 Repository (migrate to labels in the primary repository)
+
+// Stories:
+// - batch rename a column
+// - batch change color of a column
+// - batch reorder columns
+// - add/remove a column/label
+// - batch "rename" a column to an existing one
+//   - if the repo already has a column with the same name then change all Issues to have that label
+//   - otherwise, rename&recolor the label
+
+import _ from 'underscore';
+import React from 'react';
+import * as BS from 'react-bootstrap';
+
+import IssueStore from '../issue-store';
+import Database from '../database';
+import {getFilters} from '../route-utils';
+
+import Loadable from './loadable';
+import LabelBadge from './label-badge';
+
+const LabelViewEdit = React.createClass({
+  getInitialState() {
+    return {isEditing: false};
+  },
+  onClickEdit() {
+    this.setState({isEditing: true});
+  },
+  onClickCancel() {
+    this.setState({isEditing: false});
+  },
+  render() {
+    const {label, repoInfos} = this.props;
+    const {isEditing} = this.state;
+    if (isEditing) {
+      return (
+        <tr>
+          <td><BS.Input ref='labelName' type='text' defaultValue={label.name}/></td>
+          <td>color?</td>
+          <td>
+            <BS.Button bsStyle='default' onClick={this.onClickCancel}>Cancel</BS.Button>
+            <BS.Button bsStyle='primary' disabled>Save</BS.Button>
+          </td>
+        </tr>
+      )
+    } else {
+      return (
+        <tr>
+          <td>
+            <LabelBadge label={label} onClick={this.onClickEdit}/>
+          </td>
+          <td>{repoInfos.length === 1 ? repoInfos[0] : repoInfos.length}</td>
+          <td><BS.Button bsStyle='link' onClick={this.onClickEdit}><i className='octicon octicon-pencil'/> Edit</BS.Button></td>
+        </tr>
+      );
+    }
+  }
+});
+
+const BatchLabelsShell = React.createClass({
+  renderLabels(labels) {
+    return _.sortBy(labels, ({name}) => name).map(({label, repoInfos}) => {
+      return (
+        <LabelViewEdit key={label.name} label={label} repoInfos={repoInfos}/>
+      )
+    });
+  },
+  renderLoaded(repoInfosWithLabels) {
+    const {repoOwner: primaryRepoOwner, repoName: primaryRepoName} = repoInfosWithLabels[0];
+
+    const labelCounts = {};
+    // keys are the label name, and value can be undefined, or `{repoInfos, label}`
+    repoInfosWithLabels.forEach(({repoOwner, repoName, labels}) => {
+      (labels || []).forEach((label) => {
+        const {name} = label;
+        const labelCount = labelCounts[name] || {repoInfos: [], label};
+        labelCount.repoInfos.push(`${repoOwner}/${repoName}`);
+        labelCounts[name] = labelCount;
+      });
+    });
+
+    const labelCountsValues = _.sortBy(_.values(labelCounts), ({label}) => label.name);
+    const primaryLabels = _.filter(labelCountsValues, ({repoInfos}) => {
+      return (repoInfos.indexOf(`${primaryRepoOwner}/${primaryRepoName}`) >= 0)
+    });
+
+    const nonPrimaryAndNonUniqueLabels = _.filter(labelCountsValues, ({repoInfos}) => {
+      return (repoInfos.indexOf(`${primaryRepoOwner}/${primaryRepoName}`) < 0) && repoInfos.length > 1;
+    });
+
+    const uniqueLabels = _.filter(labelCountsValues, ({repoInfos}) => {
+      return (repoInfos.indexOf(`${primaryRepoOwner}/${primaryRepoName}`) < 0) && repoInfos.length === 1;
+    });
+
+
+
+    return (
+      <BS.Grid>
+        <BS.Row>
+          <BS.Col md={6}>
+            <BS.Panel header='Primary Repository'>
+              These are labels on the primary repository that may affect other repositories
+              <BS.Table responsive hover>
+                <tbody>
+                  {this.renderLabels(primaryLabels)}
+                </tbody>
+              </BS.Table>
+            </BS.Panel>
+          </BS.Col>
+          <BS.Col md={6}>
+            <BS.Panel header='Labels in more than 1 repository'>
+              These are labels in multiple repositories (but not the primary repository)
+              <BS.Table responsive hover>
+                <tbody>
+                  {this.renderLabels(nonPrimaryAndNonUniqueLabels)}
+                </tbody>
+              </BS.Table>
+            </BS.Panel>
+          </BS.Col>
+          <BS.Col md={6}>
+            <BS.Panel header='Labels unique to 1 repository'>
+              These are labels that are unique to 1 repository (but not in the primary repository)
+              <BS.Table responsive hover>
+                <tbody>
+                  {this.renderLabels(uniqueLabels)}
+                </tbody>
+              </BS.Table>
+            </BS.Panel>
+          </BS.Col>
+        </BS.Row>
+      </BS.Grid>
+    );
+  },
+  render() {
+    const {repoInfos} = getFilters().getState();
+    const promise = IssueStore.fetchConcreteRepoInfos(repoInfos)
+    .then((concreteRepoInfos) => {
+      return Promise.all(concreteRepoInfos.map(({repoOwner, repoName}) => {
+        return IssueStore.fetchRepoLabels(repoOwner, repoName);
+      }));
+    });
+    return (
+      <Loadable
+        promise={promise}
+        renderLoaded={this.renderLoaded}
+      />
+    )
+  }
+});
+
+export default BatchLabelsShell;

--- a/src/components/board.jsx
+++ b/src/components/board.jsx
@@ -113,7 +113,7 @@ const Board = React.createClass({
     const {repoInfos, columnDataPromise} = this.props;
     const progress = new Progress();
     const cardsPromise = IssueStore.fetchIssues().then((cards) => {
-      return Database.fetchCards(getFilters().getState()) || cards;
+      return Database.fetchCards(getFilters()) || cards;
     });
 
     return (

--- a/src/components/burnup.jsx
+++ b/src/components/burnup.jsx
@@ -232,7 +232,7 @@ const BurnupShell = React.createClass({
   },
   render() {
     // TODO: send the current filter as an arg to `Database.fetchCards()` so it can smartly (using Indexes) fetch the cards
-    const promise = Database.fetchCards(getFilters().getState());
+    const promise = Database.fetchCards(getFilters();
 
     return (
       <div className='burnup'>

--- a/src/components/burnup.jsx
+++ b/src/components/burnup.jsx
@@ -232,7 +232,7 @@ const BurnupShell = React.createClass({
   },
   render() {
     // TODO: send the current filter as an arg to `Database.fetchCards()` so it can smartly (using Indexes) fetch the cards
-    const promise = Database.fetchCards(getFilters();
+    const promise = Database.fetchCards(getFilters());
 
     return (
       <div className='burnup'>

--- a/src/components/issue.jsx
+++ b/src/components/issue.jsx
@@ -146,7 +146,7 @@ let Issue = React.createClass({
           placement='top'
           delayShow={1000}
           overlay={tooltip}>
-          <LabelBadge isClickable label={label}/>
+          <LabelBadge isFilterLink label={label}/>
         </BS.OverlayTrigger>
       );
     });

--- a/src/components/label-badge.jsx
+++ b/src/components/label-badge.jsx
@@ -13,7 +13,7 @@ const LabelBadge = React.createClass({
     extra: React.PropTypes.string
   },
   render() {
-    const {label, isClickable} = this.props;
+    const {label, isFilterLink, onClick} = this.props;
     let {className, extra} = this.props;
 
     let name;
@@ -37,7 +37,7 @@ const LabelBadge = React.createClass({
       extra = ` (${extra})`;
     }
 
-    if (isClickable) {
+    if (isFilterLink) {
       return (
         <Link to={getFilters().toggleTagName(label.name).url()}
           key={name}
@@ -58,6 +58,7 @@ const LabelBadge = React.createClass({
           key={name}
           {...this.props}
           className={className}
+          onClick={onClick}
           style={{backgroundColor: '#' + label.color}}>
           {icon}
           <GithubFlavoredMarkdown

--- a/src/database.js
+++ b/src/database.js
@@ -26,9 +26,9 @@ const DB_DATA = {
     //   { name: '[kanbanColumn+state]', keyPath: ['kanbanColumn', 'state'], unique: false, multiEntry: false },
     ]
   },
-  // 'labels': { // contains repoOwner, repoName, labels
-  //   dbVersion: 1,
-  // },
+  'repoLabels': { // contains repoOwner, repoName, labels
+    dbVersion: 1,
+  },
   'repositories': {
     dbVersion: 1,
     // indexes: [
@@ -262,22 +262,19 @@ const database = new class Database {
     return this._doOp('issues', 'batch', batchOps, this._opts);
   }
 
-  getLabel(labelName) {
-    return this._doOp('labels', 'get', labelName, this._opts);
-  }
-  putLabel(repoOwner, repoName, label) {
-    const {name, color} = label;
-    return this._doOp('labels', 'put', name, {color, repoOwner, repoName}, this._opts);
-  }
+  // getLabel(labelName) {
+  //   return this._doOp('labels', 'get', labelName, this._opts);
+  // }
+  // putLabel(repoOwner, repoName, label) {
+  //   const {name, color} = label;
+  //   return this._doOp('labels', 'put', name, {color, repoOwner, repoName}, this._opts);
+  // }
 
   putRepoLabels(repoOwner, repoName, labels) {
-    return this.patchRepo(repoOwner, repoName, {labels});
+    return this._doOp('repoLabels', 'put', `${repoOwner}/${repoName}`, {repoOwner, repoName, labels});
   }
   getRepoLabels(repoOwner, repoName) {
-    return this._doOp('repositories', 'get', `${repoOwner}/${repoName}`)
-    .then(({labels}) => {
-      return {repoOwner, repoName, labels} || null;
-    });
+    return this._doOp('repoLabels', 'get', `${repoOwner}/${repoName}`);
   }
   getRepoLabelsOrNull(repoOwner, repoName) {
     return new Promise((resolve, reject) => {

--- a/src/github-client.js
+++ b/src/github-client.js
@@ -169,7 +169,7 @@ class Client extends EventEmitter {
     this.LOW_RATE_LIMIT = 60;
   }
   // Used for checking if we should retreive ALL Issues or just open ones
-  canCacheLots() { return this.hasCredentials() && !!cacheHandler._db; }
+  canCacheLots() { return this.hasCredentials() /*&& !!cacheHandler._db*/; }
   dbPromise() { return cacheHandler.dbPromise; }
   off() { // EventEmitter has `.on` but no matching `.off`
     const slice = [].slice;

--- a/src/route-utils.js
+++ b/src/route-utils.js
@@ -231,6 +231,10 @@ export function getFilters() {
   return FILTER_STATE;
 }
 
+export function getFreshFilter() {
+  return new FilterState(DEFAULTS);
+}
+
 export const LABEL_CACHE = {}; // keys are label names and values are the label object (contains color)
 
 
@@ -257,9 +261,10 @@ function matchesRepoInfo(repoInfos, card) {
 
 // Filters the list of cards by the criteria set in the URL.
 // Used by IssueStore.fetchIssues()
-export function filterCardsByFilter(cards) {
-  const {repoInfos, milestoneTitles, userName, states, types, columnRegExp} = getFilters().getState();
-  let {tagNames, columnLabels} = getFilters().getState(); // We might remove UNCATEGORIZED_NAME from the list
+export function filterCardsByFilter(cards, filter) {
+  filter = filter || getFilters();
+  const {repoInfos, milestoneTitles, userName, states, types, columnRegExp} = filter.getState();
+  let {tagNames, columnLabels} = filter.getState(); // We might remove UNCATEGORIZED_NAME from the list
   const includedTagNames = tagNames.filter((tagName) => { return tagName[0] !== '-'; });
   const excludedTagNames = tagNames.filter((tagName) => { return tagName[0] === '-'; }).map((tagName) => { return tagName.substring(1); });
 

--- a/src/router.js
+++ b/src/router.js
@@ -12,6 +12,7 @@ import MergedSince from './components/merged-since';
 import {MergedSinceFormShell} from './components/merged-since';
 import DiffEnvs from './components/diff-envs';
 import EtherpadShell from './components/etherpad';
+import BatchLabelsShell from './components/batch-labels';
 
 import {parseRoute, buildRoute} from './route-utils';
 
@@ -46,6 +47,7 @@ const routes = [
           { path: 'compare/:startShas(/:endShas)', component: MergedSince},
           { path: 'by-milestone', component: ByMilestoneView },
           { path: 'by-user', component: ByUserView },
+          { path: 'labels', component: BatchLabelsShell },
           // Redirect to the gantt URL
           { path: 'milestone-review', onEnter: (state, replace) => replace(null, buildRoute('gantt', parseRoute(state))) },
           { path: 'gantt',


### PR DESCRIPTION
Labels can be renamed but unfortunately, GitHub does not fire an event when that occurs so we have to fetch the set of labels and compare them to what the DB thinks they are. If a label is renamed then we need to update all the Issues that had that label so the local Issue matches the one in GitHub.

This is the first step to make batch renaming of labels and milestones.

# The Label Management Screen

![image](https://cloud.githubusercontent.com/assets/253202/14439526/8965b6a6-fff9-11e5-8634-8c2540b8d0be.png)
