### PR TITLE
adds option to show simple list instead of detailed cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,9 +183,10 @@ Just specify a GitHub repository in the URL and off you go!
 - [x] support milestone (sprint) planning by making each milestone a column
 - [x] show labels unique to each repository
 - [x] linked Issues & PR's should include the title
-- [ ] add GitHub search
-- [ ] add a list view in addition to a board (uses Due Dates)
+- [x] collaboratively edit Milestones and any GitHub file by going to `/p-file/:repoOwner/:repoName/:branch/path-to-file`
+- [x] add a list view in addition to a board
+  - [ ] Sort by Due At, Updated At, and ascending/descending
 - [ ] add a way to add labels/milestones to an Issue (autocreate the label/milestone in the repo)
-- [ ] 1-click to move to the next column
 - [ ] cache issues-updated-since requests and CI status requests in Session Storage instead of IndexedDB so they can be cleared easier
-- [ ] collaboratively edit Milestones and any GitHub file
+- [ ] add effort labels XS, S, M, L, XL
+- [ ] add GitHub search

--- a/src/components/app/nav.jsx
+++ b/src/components/app/nav.jsx
@@ -202,6 +202,13 @@ const AppNav = React.createClass({
             <BS.NavDropdown key='settings' id='display-settings' title={settingsTitle}>
               <BS.MenuItem key='display' header>Display Settings</BS.MenuItem>
               <SettingsItem
+                key='ShowSimpleList'
+                onSelect={SettingsStore.toggleShowSimpleList.bind(SettingsStore)}
+                isChecked={SettingsStore.getShowSimpleList()}
+                >
+                Show Simple List
+              </SettingsItem>
+              <SettingsItem
                 key='HideUncategorized'
                 onSelect={SettingsStore.toggleHideUncategorized.bind(SettingsStore)}
                 isChecked={SettingsStore.getHideUncategorized()}

--- a/src/components/gfm.jsx
+++ b/src/components/gfm.jsx
@@ -3,6 +3,8 @@ import ReactDOM from 'react-dom';
 import _ from 'underscore';
 import ultramarked from 'ultramarked';
 import linkify from 'gfm-linkify';
+import classnames from 'classnames';
+
 // import mermaid, {mermaidAPI} from 'mermaid';
 // import mermaidAPI from 'mermaid/dist/mermaidAPI';
 
@@ -237,7 +239,7 @@ const InnerMarkdown = React.createClass({
     });
   },
   render() {
-    const {text, repoOwner, repoName, inline} = this.props;
+    const {text, repoOwner, repoName, inline, className} = this.props;
     if (!text) { return null; }
     const hasHtmlTags = /</.test(text);
     const context = repoOwner + '/' + repoName;
@@ -255,13 +257,13 @@ const InnerMarkdown = React.createClass({
           // (ie for a title)
           const inlineHtml = html.replace(/^<p>/, '').replace(/<\/p>\n$/, '');
           const props = {
-            className: 'markdown-body',
+            className: classnames(['markdown-body', className]),
             dangerouslySetInnerHTML: {__html: inlineHtml}
           };
           return (<span {...props}/>);
         } else {
           const props = {
-            className: 'markdown-body',
+            className: classnames(['markdown-body', className]),
             dangerouslySetInnerHTML: {__html: html}
           };
           return (<div {...props}/>);

--- a/src/settings-store.js
+++ b/src/settings-store.js
@@ -20,6 +20,7 @@ function localSet(key, val) {
   }
 }
 
+let isShowSimpleList = localGet('isShowSimpleList') || false;
 let isHideUncategorized = localGet('isHideUncategorized') || false;
 let isShowEmptyColumns = localGet('isShowEmptyColumns') || false;
 let isTableLayout = localGet('isTableLayout') || false;
@@ -39,6 +40,14 @@ class SettingsStore extends EventEmitter {
     this.emit('change');
   }
 
+  toggleShowSimpleList() {
+    isShowSimpleList = !isShowSimpleList;
+    localSet('isShowSimpleList', isShowSimpleList);
+    this.emit('change');
+  }
+  getShowSimpleList() {
+    return isShowSimpleList;
+  }
   toggleHideUncategorized() {
     isHideUncategorized = !isHideUncategorized;
     localSet('isHideUncategorized', isHideUncategorized);

--- a/style/app.less
+++ b/style/app.less
@@ -305,6 +305,34 @@ body { background-color: #ddd; }
     margin-right: 1rem;
     border-radius: 3px !important;
 
+    // Inspired by http://the-echoplex.net/flexyboxes/
+    &.is-simple-list {
+      border-radius: 0 !important;
+      margin: 1px;
+      // border: 1px solid black;
+      padding: .5rem;
+      display: flex;
+
+      flex-direction: row;
+      flex-wrap: nowrap;
+      justify-content: flex-start;
+      align-items: flex-start;
+      align-content: stretch;
+
+      .avatar-filter { flex: 0 0 auto; }
+      .issue-title {
+        flex: 1 1 auto;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        overflow-x: hidden;
+        padding-left: 1rem;
+      }
+      .issue-number {
+        flex: 0 0 auto;
+        color: #ccc;
+      }
+    }
+
     /* Just make the issue gray so it is clear we are dragging this element from */
     &.is-dragging { opacity: .25; }
 


### PR DESCRIPTION
The idea is to make `gh-board` look more like Todo lists for people that don't want distractions or just want _something simple_ (but still keep the data in GitHub 😄 ).

Also, there's a TODO list after the screenshots for features to add.

Refs #17. This was a feature requested by @pgrimald and might be nice/useful for @InconceivableVizzini, @nyxer95, or @openstaxalina. /cc'ing for thoughts/feedback 💭 


# Enabled

![image](https://cloud.githubusercontent.com/assets/253202/15033348/b7ecbe52-1237-11e6-989e-30378427c2aa.png)

# Disabled (default)

![image](https://cloud.githubusercontent.com/assets/253202/15033333/980011f2-1237-11e6-96d2-848f93c8dadf.png)

# How to enable

![image](https://cloud.githubusercontent.com/assets/253202/15033364/dd5852e6-1237-11e6-95f8-52967ecfd0ab.png)


# TODO

- [ ] add a checkbox to do batch operations (like close the issue)
- [ ] Sort by due date (if there is one)
  - [ ] show the due date (maybe show the date when the list is wide, ie 1 or 2 columns)
- [ ] add a simple button to add to the list (<kbd>Create an Issue</kbd>)