### PR TITLE
remove GFM on label

### DIFF
--- a/src/components/label-badge.jsx
+++ b/src/components/label-badge.jsx
@@ -6,7 +6,6 @@ import {ListUnorderedIcon, TagIcon} from 'react-octicons';
 
 import {getFilters} from '../route-utils';
 import {KANBAN_LABEL, isLight} from '../helpers';
-import GithubFlavoredMarkdown from './gfm';
 
 const LabelBadge = React.createClass({
   propTypes: {
@@ -47,10 +46,7 @@ const LabelBadge = React.createClass({
           className={className}
           style={{backgroundColor: '#' + label.color}}>
           {icon}
-          <GithubFlavoredMarkdown
-            inline
-            text={name}
-          />
+          {name}
           {extra}
         </Link>
       );
@@ -63,10 +59,7 @@ const LabelBadge = React.createClass({
           onClick={onClick}
           style={{backgroundColor: '#' + label.color}}>
           {icon}
-          <GithubFlavoredMarkdown
-            inline
-            text={name}
-          />
+          {name}
           {extra}
         </BS.Badge>
       );


### PR DESCRIPTION
Labels like `- label` breaks the UI as GFM will create a `ul` element.

I've never seen a label with markdown. Is that common?